### PR TITLE
watson test using creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tests/.gitignore
 tests/.project
 tests/.settings/
 tests/credentials.json
+tests/vcap_services.json
 
 # Linux
 *~

--- a/README.md
+++ b/README.md
@@ -66,7 +66,27 @@ The `$user_prefix` is usually your dockerhub user id.
 
 ### Testing
 
+Note: If you're running all tests locally (either of these two commands: `./gradlew tests:test` or `./gradlew tests:test --tests *CredentialsIBMNodeJsActionWatsonTests`), you need to set up a tests/vcap_services.json file containing Watson credentials in the format of:
+```  
+{  
+  "language_translation":[  
+    {  
+      "name":"",  
+      "label":"",  
+      "plan":"",  
+      "credentials": {  
+        "url": "",  
+        "password": "",  
+        "username": ""  
+      }  
+    }  
+  ]  
+}  
+```  
+
 To run all tests: `./gradlew tests:test`
+
+To run all tests except those which do not rely on credentials `./gradlew tests:testWithoutCredentials`
 
 To run a single test-class: `./gradlew tests:test --tests <SomeGradleTestFilter>`
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -17,6 +17,10 @@ tasks.withType(Test) {
     outputs.upToDateWhen { false } // force tests to run every time
 }
 
+task testWithoutCredentials(type: Test) {
+  exclude '**/*Credentials*'
+}
+
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':whisktests')

--- a/tests/dat/testWatsonAction2.js
+++ b/tests/dat/testWatsonAction2.js
@@ -1,0 +1,29 @@
+
+var LanguageTranslationV2 = require('watson-developer-cloud/language-translation/v2');
+
+/*
+Args in the form of:
+  args.url;
+  args.username;
+  args.password;
+*/
+function main(args){
+  language_translation = new LanguageTranslationV2(args);
+  var params = {
+    text: 'hello',
+    source: 'en',
+    target: 'es'
+  };
+
+  var promise = new Promise(function (resolve, reject) {
+    language_translation.translate(params, function(err, body){
+      if(err){
+        reject(err);
+      }
+      resolve(body);
+    });
+
+  });
+  return promise;
+
+}

--- a/tests/src/test/scala/actionContainers/CredentialsIBMNodeJsActionWatsonTests.scala
+++ b/tests/src/test/scala/actionContainers/CredentialsIBMNodeJsActionWatsonTests.scala
@@ -1,0 +1,49 @@
+package actionContainers
+
+import common.TestHelpers
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import common.WskTestHelpers
+import common.Wsk
+import common.WskProps
+import java.io.File
+import spray.json._
+import common.TestUtils
+import org.scalatest.BeforeAndAfterAll
+@RunWith(classOf[JUnitRunner])
+class CredentialsIBMNodeJsActionWatsonTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
+
+  implicit val wskprops: WskProps = WskProps()
+  var defaultKind = Some("nodejs-ibm:8")
+  val wsk = new Wsk
+  val datdir = System.getProperty("user.dir") + "/dat/"
+
+  var creds = TestUtils.getVCAPcredentials("language_translator")
+
+  /*
+    Uses Watson Translation Service to translate the word "Hello" in English, to "Hola" in Spanish.
+   */
+  it should "Test whether watson translate service is reachable" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val file = Some(new File(datdir, "testWatsonAction2.js").toString())
+    assetHelper.withCleaner(wsk.action, "testWatsonAction2") { (action, _) =>
+      action.create(
+        "testWatsonAction2",
+        file,
+        main = Some("main"),
+        kind = defaultKind,
+        parameters = Map(
+          "url" -> JsString(creds.get("url")),
+          "username" -> JsString(creds.get("username")),
+          "password" -> JsString(creds.get("password"))))
+    }
+
+    withActivation(wsk.activation, wsk.action.invoke("testWatsonAction2")) { activation =>
+      val response = activation.response
+      response.result.get.fields.get("error") shouldBe empty
+      response.result.get.fields.get("translations") should be(
+        Some(JsArray(JsObject("translation" -> JsString("Hola")))))
+    }
+
+  }
+
+}

--- a/tests/src/test/scala/actionContainers/IBMNodeJsActionWatsonTests.scala
+++ b/tests/src/test/scala/actionContainers/IBMNodeJsActionWatsonTests.scala
@@ -8,10 +8,8 @@ import common.Wsk
 import common.WskProps
 import java.io.File
 import spray.json._
-import common.TestUtils
 import spray.json.DefaultJsonProtocol._
 import org.scalatest.BeforeAndAfterAll
-
 @RunWith(classOf[JUnitRunner])
 class IBMNodeJsActionWatsonTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
 
@@ -19,8 +17,6 @@ class IBMNodeJsActionWatsonTests extends TestHelpers with WskTestHelpers with Be
   var defaultKind = Some("nodejs-ibm:8")
   val wsk = new Wsk
   val datdir = System.getProperty("user.dir") + "/dat/"
-
-  var creds = TestUtils.getVCAPcredentials("language_translator")
 
   it should "Test whether or not watson package is useable within a nodejs8 action" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
@@ -46,32 +42,6 @@ class IBMNodeJsActionWatsonTests extends TestHelpers with WskTestHelpers with Be
         response.result.get.fields.get("error") shouldBe empty
         response.result.get.fields.get("message") should be(Some(JsString("2017-08-01")))
       }
-
-  }
-
-  /*
-    Uses Watson Translation Service to translate the word "Hello" in English, to "Hola" in Spanish.
-   */
-  it should "Test whether watson translate service is reachable" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val file = Some(new File(datdir, "testWatsonAction2.js").toString())
-    assetHelper.withCleaner(wsk.action, "testWatsonAction2") { (action, _) =>
-      action.create(
-        "testWatsonAction2",
-        file,
-        main = Some("main"),
-        kind = defaultKind,
-        parameters = Map(
-          "url" -> JsString(creds.get("url")),
-          "username" -> JsString(creds.get("username")),
-          "password" -> JsString(creds.get("password"))))
-    }
-
-    withActivation(wsk.activation, wsk.action.invoke("testWatsonAction2")) { activation =>
-      val response = activation.response
-      response.result.get.fields.get("error") shouldBe empty
-      response.result.get.fields.get("translations") should be(
-        Some(JsArray(JsObject("translation" -> JsString("Hola")))))
-    }
 
   }
 

--- a/tests/src/test/scala/actionContainers/IBMNodeJsActionWatsonTests.scala
+++ b/tests/src/test/scala/actionContainers/IBMNodeJsActionWatsonTests.scala
@@ -8,10 +8,9 @@ import common.Wsk
 import common.WskProps
 import java.io.File
 import spray.json._
+import common.TestUtils
 import spray.json.DefaultJsonProtocol._
 import org.scalatest.BeforeAndAfterAll
-
-// Run test suite with : `./gradlew tests:test --tests *IBMNodeJsActionWatsonTests`
 
 @RunWith(classOf[JUnitRunner])
 class IBMNodeJsActionWatsonTests extends TestHelpers with WskTestHelpers with BeforeAndAfterAll {
@@ -20,6 +19,8 @@ class IBMNodeJsActionWatsonTests extends TestHelpers with WskTestHelpers with Be
   var defaultKind = Some("nodejs-ibm:8")
   val wsk = new Wsk
   val datdir = System.getProperty("user.dir") + "/dat/"
+
+  var creds = TestUtils.getVCAPcredentials("language_translator")
 
   it should "Test whether or not watson package is useable within a nodejs8 action" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
@@ -47,4 +48,31 @@ class IBMNodeJsActionWatsonTests extends TestHelpers with WskTestHelpers with Be
       }
 
   }
+
+  /*
+    Uses Watson Translation Service to translate the word "Hello" in English, to "Hola" in Spanish.
+   */
+  it should "Test whether watson translate service is reachable" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val file = Some(new File(datdir, "testWatsonAction2.js").toString())
+    assetHelper.withCleaner(wsk.action, "testWatsonAction2") { (action, _) =>
+      action.create(
+        "testWatsonAction2",
+        file,
+        main = Some("main"),
+        kind = defaultKind,
+        parameters = Map(
+          "url" -> JsString(creds.get("url")),
+          "username" -> JsString(creds.get("username")),
+          "password" -> JsString(creds.get("password"))))
+    }
+
+    withActivation(wsk.activation, wsk.action.invoke("testWatsonAction2")) { activation =>
+      val response = activation.response
+      response.result.get.fields.get("error") shouldBe empty
+      response.result.get.fields.get("translations") should be(
+        Some(JsArray(JsObject("translation" -> JsString("Hola")))))
+    }
+
+  }
+
 }

--- a/tools/travis/test.sh
+++ b/tools/travis/test.sh
@@ -24,7 +24,14 @@ fi
 export OPENWHISK_HOME=$WHISKDIR
 cd ${ROOTDIR}
 TERM=dumb ./gradlew :tests:checkScalafmtAll
-TERM=dumb ./gradlew :tests:testWithoutCredentials
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  TERM=dumb ./gradlew :tests:test
+else
+  TERM=dumb ./gradlew :tests:testWithoutCredentials
+fi
+
+
+
 
 #For some reason there no activations, maybe index not ready
 #${WHISK_CLI} activation get --last

--- a/tools/travis/test.sh
+++ b/tools/travis/test.sh
@@ -24,7 +24,7 @@ fi
 export OPENWHISK_HOME=$WHISKDIR
 cd ${ROOTDIR}
 TERM=dumb ./gradlew :tests:checkScalafmtAll
-TERM=dumb ./gradlew :tests:test
+TERM=dumb ./gradlew :tests:testWithoutCredentials
 
 #For some reason there no activations, maybe index not ready
 #${WHISK_CLI} activation get --last


### PR DESCRIPTION
This particular commit is failing.
But when my branch creds are provided - it succeeds.

Adds a test that uses credentials to access a Watson endpoint to translate the word 'Hello' into Spanish. 