### PR TITLE
add cloudant tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,21 @@ you need to set up a tests/credentials.json file containing Watson credentials i
         "username": ""  
       }  
     }  
-  ]  
+  ],  
+  "cloudantNoSQLDB":[
+    {
+      "name":"",  
+      "label":"",  
+      "plan":"",  
+      "credentials": {  
+        "url": "",  
+        "host": "",  
+        "port": "" ,  
+        "password": "",  
+        "username": ""  
+      }  
+    }
+  ]
 }  
 ```
 Then update the `whisk.properties` file located in the directory `$OPENWHISK_HOME`, using the variable `vcap.services.file`

--- a/tests/dat/testCloudantAction.js
+++ b/tests/dat/testCloudantAction.js
@@ -1,0 +1,38 @@
+var Cloudant = require("cloudant");
+
+function main(args){
+  var username = args.username;
+  var password = args.password;
+  var dbName = "test_cloud_functions_nodejs_8_ibm_runtime"
+
+  //Configuration to use Cloudant
+  var cloudant = Cloudant({account:username, password:password, plugin:'promises'});
+  //Create the cloudant database
+  return cloudant.db.create(dbName)
+  .then(function(data){
+    //Switch to use that newly created database.
+    return cloudant.db.use(dbName);
+  })
+  .then(function(db){
+    var friendinfo;
+    //Inject a json document named friend1 into the database.
+    return db.insert({firstname: "Suzzy", lastname: "Queue"}, 'friend1')
+    .then(function(){
+      //fetch the newly injected document from the database
+      return db.get('friend1');
+    })
+    .then(function(data){
+      friendinfo = data;
+      //destroy the database
+      return cloudant.db.destroy(dbName);
+    })
+    .then(function(){
+      //return the document fetched from the db
+      return friendinfo;
+    })
+  })
+  .catch(function(err){
+    //If an error occurrs at any part in execution; return error
+    return {err: err}
+  })
+}

--- a/tests/src/test/scala/actionContainers/CredentialsIBMNodeJsActionCloudantTests.scala
+++ b/tests/src/test/scala/actionContainers/CredentialsIBMNodeJsActionCloudantTests.scala
@@ -1,0 +1,43 @@
+package actionContainers
+
+import common.TestHelpers
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import common.WskTestHelpers
+import common.Wsk
+import common.WskProps
+import java.io.File
+import spray.json._
+import common.TestUtils
+
+@RunWith(classOf[JUnitRunner])
+class CredentialsIBMNodeJsActionCloudantTests extends TestHelpers with WskTestHelpers {
+
+  implicit val wskprops: WskProps = WskProps()
+  var defaultKind = Some("nodejs-ibm:8")
+  val wsk = new Wsk
+  val datdir = System.getProperty("user.dir") + "/dat/"
+  var creds = TestUtils.getVCAPcredentials("cloudantNoSQLDB")
+
+  it should "Test whether or not cloudant npm module is useable within a nodejs8 action" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val file = Some(new File(datdir, "testCloudantAction.js").toString())
+
+      assetHelper.withCleaner(wsk.action, "testCloudantAction") { (action, _) =>
+        action.create(
+          "testCloudantAction",
+          file,
+          main = Some("main"),
+          kind = defaultKind,
+          parameters = Map("username" -> JsString(creds.get("username")), "password" -> JsString(creds.get("password"))))
+      }
+
+      withActivation(wsk.activation, wsk.action.invoke("testCloudantAction")) { activation =>
+        val response = activation.response
+        response.result.get.fields.get("error") shouldBe empty
+        response.result.get.fields.get("lastname") should be(Some(JsString("Queue")))
+      }
+
+  }
+
+}


### PR DESCRIPTION
Tests action that uses cloudant npm package to create, insert, get, and destroy database using encrypted credentials.

references https://github.com/ibm-functions/runtime-nodejs/issues/40
