### PR TITLE
add @cloudant/cloudant npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The runtime provides [nodejs v8](nodejs8/) with a set of [npm packages](nodejs8/
 
 The runtime provides the following npm packages for [IBM Cloud](https://bluemix.net):
 - IBM DB2/DashDB and IBM Informix [ibm_db@2.2.1](https://www.npmjs.com/package/ibm_db)
-- IBM Cloudant [cloudant@1.10.0](https://www.npmjs.com/package/cloudant)
+- IBM Cloudant [cloudant@1.10.0](https://www.npmjs.com/package/cloudant) & [@cloudant/cloudant@2.1.0](https://www.npmjs.com/package/@cloudant/cloudant)
 - IBM Watson Cloud [watson-developer-cloud@2.42.0](https://www.npmjs.com/package/watson-developer-cloud)
 - IBM Cloud Object Storage [ibm-cos-sdk@1.0.2](https://www.npmjs.com/package/ibm-cos-sdk)
 

--- a/nodejs8/package.json
+++ b/nodejs8/package.json
@@ -17,6 +17,7 @@
     "btoa": "1.1.2",
     "cassandra-driver": "3.4.1",
     "cloudant": "1.10.0",
+    "@cloudant/cloudant": "2.1.0",
     "commander": "2.15.0",
     "composeaddresstranslator": "1.0.4",
     "consul": "0.30.0",


### PR DESCRIPTION
The Cloudant Node.js library used to be deployed with `npm install cloudant` but has recently been moved to `npm install @cloudant/cloudant`. This pull request adds the newer library without removing the old one (for now).

[@cloudant/cloudant](https://www.npmjs.com/package/@cloudant/cloudant)

[cloudant (deprecated)](https://www.npmjs.com/package/cloudant)