### PR TITLE
update Travis to push "master" tag to Docker on "master" branch merges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,14 @@ install: true
 script:
 - "./tools/travis/build.sh && ./tools/travis/deploy.sh && ./tools/travis/test.sh"
 deploy:
-- provider: script
-  script: "./tools/travis/publish.sh ibmfunctions $TRAVIS_TAG"
-  on:
-    tags: true
-    all_branches: true
-    repo: ibm-functions/runtime-nodejs
+  - provider: script
+    script: "./tools/travis/publish.sh ibmfunctions $TRAVIS_TAG"
+    on:
+      tags: true
+      all_branches: true
+      repo: ibm-functions/runtime-nodejs
+  - provider: script
+    script: "./tools/travis/publish.sh ibmfunctions master"
+    on:
+      branch: master
+


### PR DESCRIPTION
Add the ability for Travis to be able to push a "master" tag to the associated Docker image when changes are merged in on the "master" branch in this repository. 

closes #102 