### PR TITLE
update COS test to be able to handle service credentials with nested …

### DIFF
--- a/tests/src/test/scala/integration/CredentialsIBMNodeJsCOSTests.scala
+++ b/tests/src/test/scala/integration/CredentialsIBMNodeJsCOSTests.scala
@@ -30,9 +30,9 @@ class CredentialsIBMNodeJsCOSTests extends TestHelpers with WskTestHelpers with 
   var defaultKind = Some("nodejs:8")
   val wsk = new WskRest
   val datdir = "tests/dat/"
-  val creds = TestUtils.getVCAPcredentials("cloud-object-storage")
-  val apikey = creds.get("apikey")
-  var resource_instance_id = creds.get("resource_instance_id")
+  val creds = TestUtils.getCredentials("cloud-object-storage")
+  val apikey = creds.get("apikey").getAsString()
+  var resource_instance_id = creds.get("resource_instance_id").getAsString()
   val __bx_creds = JsObject(
     "cloud-object-storage" -> JsObject(
       "apikey" -> JsString(apikey),


### PR DESCRIPTION
…object in VCAP

Certain other Cloud Object Storage tests need to have an updated set of service credentials to work properly.  These new service credentials include and HMAC key which is in the nested object on the credentials object in the VCAP_SERVICES.json file.

The previous way to fetch the VCAP credentials , "getVCAPCredentials" did not handle nested objects and would crash.  So this code had to be updated. 