### PR TITLE
fix Watson Version

### DIFF
--- a/tests/dat/testWatsonAction2.js
+++ b/tests/dat/testWatsonAction2.js
@@ -1,5 +1,5 @@
 
-var LanguageTranslatorV2 = require('watson-developer-cloud/language-translator/v2');
+var LanguageTranslatorV3 = require('watson-developer-cloud/language-translator/v3');
 
 /*
 Args in the form of:
@@ -8,7 +8,7 @@ Args in the form of:
   args.password;
 */
 function main(args){
-  var language_translator = new LanguageTranslatorV2(args);
+  var language_translator = new LanguageTranslatorV3(args);
   var params = {
     text: 'hello',
     source: 'en',

--- a/tests/src/test/scala/integration/CredentialsIBMNodeJsActionWatsonTests.scala
+++ b/tests/src/test/scala/integration/CredentialsIBMNodeJsActionWatsonTests.scala
@@ -49,6 +49,7 @@ class CredentialsIBMNodeJsActionWatsonTests
         main = Some("main"),
         kind = defaultKind,
         parameters = Map(
+          "version" -> JsString("2018-05-01"),
           "url" -> JsString(creds.get("url")),
           "username" -> JsString(creds.get("username")),
           "password" -> JsString(creds.get("password"))))


### PR DESCRIPTION
Watson translation API version2 isn't supported any longer.
Upgrade to Watson translation API version3

Info: API version3 requires an additional version parameter
see: https://www.ibm.com/watson/developercloud/language-translator/api/v3/node.html?node#versioning