### PR TITLE
update npm package vcap 0.6.0

### DIFF
--- a/nodejs8/package.json
+++ b/nodejs8/package.json
@@ -71,7 +71,7 @@
     "url-pattern": "1.0.3",
     "uuid": "3.3.2",
     "validator": "10.8.0",
-    "vcap_services": "^0.6.0",
+    "vcap_services": "0.6.0",
     "watson-developer-cloud": "3.12.0",
     "when": "3.7.8",
     "winston": "3.1.0",

--- a/nodejs8/package.json
+++ b/nodejs8/package.json
@@ -71,7 +71,7 @@
     "url-pattern": "1.0.3",
     "uuid": "3.3.2",
     "validator": "10.8.0",
-    "vcap_services": "0.5.1",
+    "vcap_services": "^0.6.0",
     "watson-developer-cloud": "3.12.0",
     "when": "3.7.8",
     "winston": "3.1.0",


### PR DESCRIPTION
This version of `vcap_services` adds a method that will allow us to remove a large amount of duplicated code in the OpenWhisk SDK.

Specifically, this method is currently in _every_ action and once this package is updated, we will be able to remove it.
```js
function getParams(theParams, service) {
  if (Object.keys(theParams).length === 0) {
    return theParams;
  }
  let bxCreds;
  // Code that checks parameters bound using service bind
  if (theParams.__bx_creds) {
    // If user has instance of service
    if (theParams.__bx_creds[service]) {
      bxCreds = theParams.__bx_creds[service];
    } else {
      // User has no instances of service
      bxCreds = {};
    }
  } else {
    bxCreds = {};
  }
  const _params = Object.assign({}, bxCreds, theParams);
  if (_params.apikey) {
    _params.iam_apikey = _params.apikey;
    delete _params.apikey;
  }
  delete _params.__bx_creds;
  return _params;
}
```

Resolves #152 