### PR TITLE
Update to gradlew 5.6.2, fix for removed getVCAPcredentials.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip


### PR DESCRIPTION
-  Update to gradlew 5.6.2 to support java 11.
-  Fix testcases to work with latest opwnwhisk (function getVCAPcredentials has been removed).