### PR TITLE
Update nodejs8 baseimage, nodejs10 baseimage and mongodb package.

### DIFF
--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -5,6 +5,89 @@
 - The `watson-developer-cloud` npm package available in `nodejs:10` is version 4.x. This version includes support for Promises. [A list of the changes made is documented](https://github.com/watson-developer-cloud/node-sdk/blob/master/UPGRADE-4.0.md).
 - The `ibm-watson` npm package available in `nodejs:10` is version 4.x. This package is the successor of package `watson-developer-cloud`. Upgrade your action code to this new package, since the former will not receive updates anymore. This version includes support for Promises. [A list of the changes made is documented](https://github.com/watson-developer-cloud/node-sdk/blob/master/UPGRADE-4.0.md).
 
+# 1.14.0
+Changes:
+  - update to a newer base image to catch fixes
+  - update mongodb from `3.1.13` to `3.3.4`
+
+NodeJS version:
+  - [10.16.3](https://nodejs.org/en/blog/release/v10.16.3)
+
+NPM Packages:
+  - [@cloudant/cloudant v3.0.2](https://www.npmjs.com/package/@cloudant/cloudant) - This is the official Cloudant library for Node.js.
+  - [@sendgrid/mail v6.3.1](https://www.npmjs.com/package/@sendgrid/mail) - Provides email support via the SendGrid API.
+  - [amqplib v0.5.3](https://www.npmjs.com/package/amqplib) - A library for making AMQP 0-9-1 clients for Node.JS.
+  - [apn v2.2.0](https://www.npmjs.com/package/apn) - A Node.js module for interfacing with the Apple Push Notification service.
+  - [async v2.6.2](https://www.npmjs.com/package/async) - Provides functions for working with asynchronous functions.
+  - [bent v1.3.0](https://www.npmjs.com/package/bent) - Functional HTTP client for Node.js w/ async/await.
+  - [body-parser v1.18.3](https://www.npmjs.com/package/body-parser) - Parse incoming request bodies in a middleware before your handlers, available under the req.body property.
+  - [btoa v1.2.1](https://www.npmjs.com/package/btoa) - A port of the browser's btoa function.
+  - [cassandra-driver v4.0.0](https://www.npmjs.com/package/cassandra-driver) - DataStax Node.js Driver for Apache Cassandra.
+  - [commander v2.19.0](https://www.npmjs.com/package/commander) - The complete solution for node.js command-line interfaces.
+  - [composeaddresstranslator v1.0.4](https://www.npmjs.com/package/composeaddresstranslator) - Address translator from Compose UI or API for Scylla databases.
+  - [consul v0.34.1](https://www.npmjs.com/package/consul) - A client for Consul, involving service discovery and configuration.
+  - [cookie-parser v1.4.4](https://www.npmjs.com/package/cookie-parser) - Parse Cookie header and populate req.cookies with an object keyed by the cookie names.
+  - [elasticsearch v15.4.1](https://www.npmjs.com/package/elasticsearch) - The official low-level Elasticsearch client for Node.js.
+  - [errorhandler v1.5.1](https://www.npmjs.com/package/errorhandler) - Development-only error handler middleware.
+  - [etcd3 v0.2.11](https://www.npmjs.com/package/etcd3) - A high-quality, production-ready client for the Protocol Buffer-based etcdv3 API.
+  - [express v4.16.4] (https://www.npmjs.com/package/express) - Fast, unopinionated, minimalist web framework for node.
+  - [express-session v1.15.6] (https://www.npmjs.com/package/express-session) - Managing sessions for express.
+  - [formidable v1.2.1](https://www.npmjs.com/package/formidable) - A Node.js module for parsing form data, especially file uploads.
+  - [glob v7.1.4](https://www.npmjs.com/package/glob) - Match files using the patterns the shell uses, like stars and stuff.
+  - [gm v1.23.1](https://www.npmjs.com/package/gm) - GraphicsMagick and ImageMagick for Node.
+  - [ibm-cos-sdk v1.5.0](https://www.npmjs.com/package/ibm-cos-sdk) - {{site.data.keyword.cos_full}} SDK for Node.js
+  - [ibm_db v2.5.2](https://www.npmjs.com/package/ibm_db) - An asynchronous/synchronous interface for node.js to IBM DB2 and IBM Informix.
+  - [ibmiotf v0.2.41](https://www.npmjs.com/package/ibmiotf) - The node.js client is used for simplifying the interaction with the IBM Watson Internet of Things Platform.
+  - [ibm-watson v4.2.1](https://www.npmjs.com/package/ibm-watson) - Node.js client library to use the Watson APIs.
+  - [iconv-lite v0.4.24](https://www.npmjs.com/package/iconv-lite) - Pure JS character encoding conversion
+  - [jsdom v13.2.0](https://www.npmjs.com/package/jsdom) - jsdom is a pure-JavaScript implementation of many web standards, notably the WHATWG DOM and HTML Standards.
+  - [jsforce v1.9.1](https://www.npmjs.com/package/jsforce)Salesforce API Library for JavaScript applications.
+  - [jsonwebtoken v8.5.1](https://www.npmjs.com/package/jsonwebtoken) - An implementation of JSON Web Tokens.
+  - [lodash v4.17.13](https://www.npmjs.com/package/lodash) - The Lodash library exported as Node.js modules.
+  - [log4js v4.0.2](https://www.npmjs.com/package/log4js) - This is a conversion of the log4js framework to work with Node.
+  - [marked v0.6.2](https://www.npmjs.com/package/marked) - A full-featured markdown parser and compiler, written in JavaScript. Built for speed.
+  - [merge v1.2.1](https://www.npmjs.com/package/merge) - Merge multiple objects into one, optionally creating a new cloned object.
+  - [moment v2.24.0](https://www.npmjs.com/package/moment) - A lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
+  - [mongodb v3.3.4](https://www.npmjs.com/package/mongodb) - The official MongoDB driver for Node.js.
+  - [mustache v3.0.1](https://www.npmjs.com/package/mustache) - mustache.js is an implementation of the mustache template system in JavaScript.
+  - [mysql v2.16.0](https://www.npmjs.com/package/mysql) - This is a node.js driver for mysql.
+  - [nano v8.0.0](https://www.npmjs.com/package/nano) - minimalistic couchdb driver for Node.js.
+  - [nodemailer v5.1.1](https://www.npmjs.com/package/nodemailer) - Send e-mails from Node.js – easy as cake!
+  - [oauth2-server v3.0.1](https://www.npmjs.com/package/oauth2-server) - Complete, compliant and well tested module for implementing an OAuth2 Server/Provider with express in Node.js.
+  - [openwhisk v3.19.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+  - [path-to-regex v3.0.0](https://www.npmjs.com/package/path-to-regexp) - Turn a path string such as /user/:name into a regular expression which can then be used to match against URL paths.
+  - [pg v7.11.0](https://www.npmjs.com/package/pg) - Non-blocking PostgreSQL client for node.js. Pure JavaScript and optional native libpq bindings.
+  - [process v0.11.10](https://www.npmjs.com/package/process) - require('process'); just like any other module.
+  - [pug v2.0.4](https://www.npmjs.com/package/pug) - Implements the Pug templating language.
+  - [redis v2.8.0](https://www.npmjs.com/package/redis) - This is a complete and feature rich Redis client for Node.js.
+  - [request v2.88.0](https://www.npmjs.com/package/request) - Request is designed to be the simplest way possible to make HTTP calls.
+  - [request-promise v4.2.4](https://www.npmjs.com/package/request-promise) - The simplified HTTP request client 'request' with Promise support. Powered by Bluebird.
+  - [rimraf v2.6.3](https://www.npmjs.com/package/rimraf) - The UNIX command rm -rf for node.
+  - [semver v5.6.0](https://www.npmjs.com/package/semver) - Semantic Versioning for Nodejs
+  - [serialize-error v3.0.0](https://www.npmjs.com/package/serialize-error) - Serialize an error into a plain object.
+  - [serve-favicon v2.5.0](https://www.npmjs.com/package/serve-favicon) - Node.js middleware for serving a favicon.
+  - [socket.io v2.2.0](https://www.npmjs.com/package/socket.io) - Socket.IO enables real-time bidirectional event-based communication.
+  - [socket.io-client v2.2.0](https://www.npmjs.com/package/socket.io-client) - Realtime application framework for socket.io.
+  - [superagent v4.1.0](https://www.npmjs.com/package/superagent) - SuperAgent is a small progressive client-side HTTP request library, and Node.js module with the same API, sporting many high-level HTTP client features.
+  - [swagger-tools v0.10.4](https://www.npmjs.com/package/swagger-tools) - Package that provides various tools for integrating and interacting with Swagger.
+  - [tmp v0.0.33](https://www.npmjs.com/package/tmp) - A simple temporary file and directory creator for node.js.
+  - [twilio v3.28.0](https://www.npmjs.com/package/twilio) - A wrapper for the Twilio API, related to voice, video, and messaging.
+  - [underscore v1.9.1](https://www.npmjs.com/package/underscore) - Underscore.js is a utility-belt library for JavaScript that provides support for the usual functional suspects (each, map, reduce, filter...) without extending any core JavaScript objects.
+  - [url-pattern v1.0.3](https://www.npmjs.com/package/url-pattern) - Parse URLs for path parameters more easily than from using a regex string matcher.
+  - [uuid v3.3.2](https://www.npmjs.com/package/uuid) - Simple, fast generation of RFC4122 UUIDS.
+  - [validator v10.11.0](https://www.npmjs.com/package/validator) - A library of string validators and sanitizers.
+  - [vcap_services v0.7.0](https://www.npmjs.com/package/vcap_services)Parse and return service credentials from VCAP_SERVICES environment variable that IBM Cloud provides.
+  - [watson-developer-cloud v4.0.0-rc2](https://www.npmjs.com/package/watson-developer-cloud) - Node.js client library to use the Watson Developer Cloud services, a collection of APIs that use cognitive computing to solve complex problems.
+  - [when v3.7.8](https://www.npmjs.com/package/when) - When.js is a rock solid, battle-tested Promises/A+ and when() implementation, including a complete ES6 Promise shim.
+  - [winston v3.2.1](https://www.npmjs.com/package/winston) - A multi-transport async logging library for node.js. "CHILL WINSTON! ... I put it in the logs."
+  - [ws v6.1.4](https://www.npmjs.com/package/ws) - ws is a simple to use, blazing fast, and thoroughly tested WebSocket client and server implementation.
+  - [xlsx v0.14.3](https://www.npmjs.com/package/xlsx) - Parser and writer for various spreadsheet formats.
+  - [xml2js v0.4.19](https://www.npmjs.com/package/xml2js) - Simple XML to JavaScript object converter. It supports bi-directional conversion.
+  - [xmlhttprequest v1.8.0](https://www.npmjs.com/package/xmlhttprequest) - node-XMLHttpRequest is a wrapper for the built-in http client to emulate the browser XMLHttpRequest object.
+  - [yauzl v2.10.0](https://www.npmjs.com/package/yauzl) - yet another unzip library for node. For zipping.
+  - [yazl v2.5.1](https://www.npmjs.com/package/yazl) - yet another zip library for node. For unzipping, see yauzl.
+
+
 # 1.13.0
 Changes:
   - update to a newer nodejs version to catch fixes

--- a/nodejs10/Dockerfile
+++ b/nodejs10/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-nodejs-v10:cb58782
+FROM openwhisk/action-nodejs-v10:314cd92
 COPY ./package.json /
 RUN cd / && npm install --production \
     && npm cache clean --force

--- a/nodejs10/package.json
+++ b/nodejs10/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-functions-runtime-nodejs-v10",
-  "version": "1.11.0",
+  "version": "1.14.0",
   "description": "IBM Functions",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "marked": "0.6.2",
     "merge": "1.2.1",
     "moment": "2.24.0",
-    "mongodb": "3.1.13",
+    "mongodb": "3.3.4",
     "mustache": "3.0.1",
     "mysql": "2.16.0",
     "nano": "8.0.0",

--- a/nodejs8/CHANGELOG.md
+++ b/nodejs8/CHANGELOG.md
@@ -1,5 +1,83 @@
 # IBM Functions NodeJS 8 Runtime Container
 
+# 1.41.0
+Changes:
+  - update to a newer base image to catch fixes
+
+NodeJS version:
+  - [8.16.1](https://nodejs.org/en/blog/release/v8.16.1)
+
+NPM Packages:
+  - [@cloudant/cloudant v2.4.1](https://www.npmjs.com/package/cloudant) - This is the official Cloudant library for Node.js.
+  - [@sendgrid/mail v6.3.1](https://www.npmjs.com/package/@sendgrid/mail) - Provides email support via the SendGrid API.
+  - [amqplib v0.5.3](https://www.npmjs.com/package/amqplib) - A library for making AMQP 0-9-1 clients for Node.JS.
+  - [apn v2.2.0](https://www.npmjs.com/package/apn) - A Node.js module for interfacing with the Apple Push Notification service.
+  - [async v2.6.2](https://www.npmjs.com/package/async) - Provides functions for working with asynchronous functions.
+  - [bent v1.3.0](https://www.npmjs.com/package/bent) - Functional HTTP client for Node.js w/ async/await.
+  - [bodyparser v1.18.3](https://www.npmjs.com/package/body-parser) - Parse incoming request bodies in a middleware before your handlers, available under the req.body property.
+  - [btoa v1.2.1](https://www.npmjs.com/package/btoa) - A port of the browser's btoa function.
+  - [cassandra-driver v3.6.0](https://www.npmjs.com/package/cassandra-driver) - DataStax Node.js Driver for Apache Cassandra.
+  - [cloudant v1.10.0](https://www.npmjs.com/package/cloudant) - This is the official Cloudant library for Node.js.
+  - [commander v2.20.0](https://www.npmjs.com/package/commander) - The complete solution for node.js command-line interfaces.
+  - [composeaddresstranslator v1.0.4](https://www.npmjs.com/package/composeaddresstranslator) - Address translator from Compose UI or API for Scylla databases.
+  - [consul v0.34.1](https://www.npmjs.com/package/consul) - A client for Consul, involving service discovery and configuration.
+  - [cookie-parser v1.4.4](https://www.npmjs.com/package/cookie-parser) - Parse Cookie header and populate req.cookies with an object keyed by the cookie names.
+  - [elasticsearch v15.4.1](https://www.npmjs.com/package/elasticsearch) - The official low-level Elasticsearch client for Node.js.
+  - [errorhandler v1.5.1](https://www.npmjs.com/package/errorhandler) - Development-only error handler middleware.
+  - [etcd3 v0.2.11](https://www.npmjs.com/package/etcd3) - A high-quality, production-ready client for the Protocol Buffer-based etcdv3 API.
+  - [formidable v1.2.1](https://www.npmjs.com/package/formidable) - A Node.js module for parsing form data, especially file uploads.
+  - [glob v7.1.4](https://www.npmjs.com/package/glob) - Match files using the patterns the shell uses, like stars and stuff.
+  - [gm v1.23.1](https://www.npmjs.com/package/gm) - GraphicsMagick and ImageMagick for Node.
+  - [ibm-cos-sdk v1.5.0](https://www.npmjs.com/package/ibm-cos-sdk) - {{site.data.keyword.cos_full}} SDK for Node.js
+  - [ibm_db v2.5.2](https://www.npmjs.com/package/ibm_db) - An asynchronous/synchronous interface for node.js to IBM DB2 and IBM Informix.
+  - [ibmiotf v0.2.41](https://www.npmjs.com/package/ibmiotf) - The node.js client is used for simplifying the interaction with the IBM Watson Internet of Things Platform.
+  - [iconv-lite v0.4.24](https://www.npmjs.com/package/iconv-lite) - Pure JS character encoding conversion
+  - [jsdom v13.2.0](https://www.npmjs.com/package/jsdom) - jsdom is a pure-JavaScript implementation of many web standards, notably the WHATWG DOM and HTML Standards.
+  - [jsforce v1.9.1](https://www.npmjs.com/package/jsforce)Salesforce API Library for JavaScript applications.
+  - [jsonwebtoken v8.4.0](https://www.npmjs.com/package/jsonwebtoken) - An implementation of JSON Web Tokens.
+  - [lodash v4.17.13](https://www.npmjs.com/package/lodash) - The Lodash library exported as Node.js modules.
+  - [log4js v3.0.6](https://www.npmjs.com/package/log4js) - This is a conversion of the log4js framework to work with Node.
+  - [marked v0.6.2](https://www.npmjs.com/package/marked) - A full-featured markdown parser and compiler, written in JavaScript. Built for speed.
+  - [merge v1.2.1](https://www.npmjs.com/package/merge) - Merge multiple objects into one, optionally creating a new cloned object.
+  - [moment v2.24.0](https://www.npmjs.com/package/moment) - A lightweight JavaScript date library for parsing, validating, manipulating, and formatting dates.
+  - [mongodb v3.1.13](https://www.npmjs.com/package/mongodb) - The official MongoDB driver for Node.js.
+  - [mustache v3.0.1](https://www.npmjs.com/package/mustache) - mustache.js is an implementation of the mustache template system in JavaScript.
+  - [mysql v2.16.0](https://www.npmjs.com/package/mysql) - This is a node.js driver for mysql.
+  - [nano v7.1.1](https://www.npmjs.com/package/nano) - minimalistic couchdb driver for Node.js.
+  - [nodemailer v4.7.0](https://www.npmjs.com/package/nodemailer) - Send e-mails from Node.js – easy as cake!
+  - [oauth2-server v3.0.1](https://www.npmjs.com/package/oauth2-server) - Complete, compliant and well tested module for implementing an OAuth2 Server/Provider with express in Node.js.
+  - [openwhisk v3.19.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+  - [path-to-regex v2.4.0](https://www.npmjs.com/package/path-to-regexp) - Turn a path string such as /user/:name into a regular expression which can then be used to match against URL paths.
+  - [pg v7.8.0](https://www.npmjs.com/package/pg) - Non-blocking PostgreSQL client for node.js. Pure JavaScript and optional native libpq bindings.
+  - [process v0.11.10](https://www.npmjs.com/package/process) - require('process'); just like any other module.
+  - [pug v2.0.4](https://www.npmjs.com/package/pug) - Implements the Pug templating language.
+  - [redis v2.8.0](https://www.npmjs.com/package/redis) - This is a complete and feature rich Redis client for Node.js.
+  - [request v2.88.0](https://www.npmjs.com/package/request) - Request is designed to be the simplest way possible to make HTTP calls.
+  - [request-promise v4.2.4](https://www.npmjs.com/package/request-promise) - The simplified HTTP request client 'request' with Promise support. Powered by Bluebird.
+  - [rimraf v2.6.3](https://www.npmjs.com/package/rimraf) - The UNIX command rm -rf for node.
+  - [semver v5.6.0](https://www.npmjs.com/package/semver) - Semantic Versioning for Nodejs
+  - [serialize-error v3.0.0](https://www.npmjs.com/package/serialize-error) - Serialize an error into a plain object.
+  - [serve-favicon v2.5.0](https://www.npmjs.com/package/serve-favicon) - Node.js middleware for serving a favicon.
+  - [socket.io v2.2.0](https://www.npmjs.com/package/socket.io) - Socket.IO enables real-time bidirectional event-based communication.
+  - [socket.io-client v2.2.0](https://www.npmjs.com/package/socket.io-client) - Realtime application framework for socket.io.
+  - [superagent v4.1.0](https://www.npmjs.com/package/superagent) - SuperAgent is a small progressive client-side HTTP request library, and Node.js module with the same API, sporting many high-level HTTP client features.
+  - [swagger-tools v0.10.4](https://www.npmjs.com/package/swagger-tools) - Package that provides various tools for integrating and interacting with Swagger.
+  - [tmp v0.0.33](https://www.npmjs.com/package/tmp) - A simple temporary file and directory creator for node.js.
+  - [twilio v3.28.0](https://www.npmjs.com/package/twilio) - A wrapper for the Twilio API, related to voice, video, and messaging.
+  - [underscore v1.9.1](https://www.npmjs.com/package/underscore) - Underscore.js is a utility-belt library for JavaScript that provides support for the usual functional suspects (each, map, reduce, filter...) without extending any core JavaScript objects.
+  - [url-pattern v1.0.3](https://www.npmjs.com/package/url-pattern) - Parse URLs for path parameters more easily than from using a regex string matcher.
+  - [uuid v3.3.2](https://www.npmjs.com/package/uuid) - Simple, fast generation of RFC4122 UUIDS.
+  - [validator v10.11.0](https://www.npmjs.com/package/validator) - A library of string validators and sanitizers.
+  - [vcap_services v0.7.0](https://www.npmjs.com/package/vcap_services)Parse and return service credentials from VCAP_SERVICES environment variable that IBM Cloud provides.
+  - [watson-developer-cloud v3.18.1](https://www.npmjs.com/package/watson-developer-cloud) - Node.js client library to use the Watson Developer Cloud services, a collection of APIs that use cognitive computing to solve complex problems.
+  - [when v3.7.8](https://www.npmjs.com/package/when) - When.js is a rock solid, battle-tested Promises/A+ and when() implementation, including a complete ES6 Promise shim.
+  - [winston v3.2.1](https://www.npmjs.com/package/winston) - A multi-transport async logging library for node.js. "CHILL WINSTON! ... I put it in the logs."
+  - [ws v6.1.4](https://www.npmjs.com/package/ws) - ws is a simple to use, blazing fast, and thoroughly tested WebSocket client and server implementation.
+  - [xml2js v0.4.19](https://www.npmjs.com/package/xml2js) - Simple XML to JavaScript object converter. It supports bi-directional conversion.
+  - [xmlhttprequest v1.8.0](https://www.npmjs.com/package/xmlhttprequest) - node-XMLHttpRequest is a wrapper for the built-in http client to emulate the browser XMLHttpRequest object.
+  - [yauzl v2.10.0](https://www.npmjs.com/package/yauzl) - yet another unzip library for node. For zipping.
+
+
 # 1.40.0
 Changes:
   - update to a newer nodejs version to catch fixes

--- a/nodejs8/Dockerfile
+++ b/nodejs8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-nodejs-v8:cb58782
+FROM openwhisk/action-nodejs-v8:314cd92
 COPY ./package.json /
 RUN cd / && npm install --production \
     && npm cache clean --force

--- a/nodejs8/package.json
+++ b/nodejs8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-functions-runtime-nodejs-v8",
-  "version": "1.38.0",
+  "version": "1.41.0",
   "description": "IBM Functions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Update nodejs8 base image to catch fixes.
- Update nodejs10 base image to catch fixes.
- Update nodejs10 package mongodb to version 3.3.4 to support MongoDB V4.2 databases. See issue #194 .