### PR TITLE
Change username/password in Watson to apikey.

### DIFF
--- a/tests/src/test/scala/runtime/integration/CredentialsIBMNodeJsActionWatsonTests.scala
+++ b/tests/src/test/scala/runtime/integration/CredentialsIBMNodeJsActionWatsonTests.scala
@@ -43,8 +43,7 @@ class CredentialsIBMNodeJsActionWatsonTests
     JsonParser(ParserInput(vcapString)).asJsObject.fields("language_translator").asInstanceOf[JsArray].elements(0)
   val creds = vcapInfo.asJsObject.fields("credentials").asJsObject
   val url = creds.fields("url").asInstanceOf[JsString]
-  val username = creds.fields("username").asInstanceOf[JsString]
-  val password = creds.fields("password").asInstanceOf[JsString]
+  val apikey = creds.fields("apikey").asInstanceOf[JsString]
 
   /*
     Uses Watson Translation Service to translate the word "Hello" in English, to "Hola" in Spanish.
@@ -57,8 +56,11 @@ class CredentialsIBMNodeJsActionWatsonTests
         file,
         main = Some("main"),
         kind = defaultKind,
-        parameters =
-          Map("version" -> JsString("2018-05-01"), "url" -> url, "username" -> username, "password" -> password))
+        parameters = Map(
+          "version" -> JsString("2018-05-01"),
+          "url" -> url,
+          "username" -> JsString("APIKey"),
+          "password" -> apikey))
     }
 
     withActivation(wsk.activation, wsk.action.invoke("testWatsonAction2")) { activation =>


### PR DESCRIPTION
- Watson instances have been updated to IAM. They now use apikey instead of username/password.