### PR TITLE
Get latest security updates with every build.

### DIFF
--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -7,6 +7,12 @@
 - The `ibm-watson` npm package available in `nodejs:10` is version 4.x. This package is the successor of package `watson-developer-cloud`. Upgrade your action code to this new package, since the former will not receive updates anymore. This version includes support for Promises. [A list of the changes made is documented](https://github.com/watson-developer-cloud/node-sdk/blob/master/UPGRADE-4.0.md).
 - The package `ibmiotf` has been renamed by the maintainers to `@wiotp/sdk`. Make sure to update your action code to the new package. See https://www.npmjs.com/package/@wiotp/sdk for all changes. The package `ibmiotf` will not receive updates anymore and will be removed from this runtime in the future.
 
+
+# 1.15.1
+Changes:
+  - Catch latest security fixes with each build.
+
+
 # 1.15.0
 Changes:
   - update to a newer base image to catch security fixes

--- a/nodejs10/Dockerfile
+++ b/nodejs10/Dockerfile
@@ -3,8 +3,8 @@ FROM openwhisk/action-nodejs-v10:7aca443
 COPY ./package.json /
 
 RUN apt-get update \
-    # Update some installed packages to get security fixes.
-    && apt-get install -y --no-install-recommends curl e2fsprogs file git openssl subversion \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
     # Cleanup apt data, we do not need them later on.
     && rm -rf /var/lib/apt/lists/* \
     # We do not have mysql-server installed but mysql-common contains config files (/etc/mysql/my.cnf) for it.

--- a/nodejs12/Dockerfile
+++ b/nodejs12/Dockerfile
@@ -3,8 +3,8 @@ FROM openwhisk/action-nodejs-v12:7aca443
 COPY ./package.json /
 
 RUN apt-get update \
-    # Update some installed packages to get security fixes.
-    && apt-get install -y --no-install-recommends curl e2fsprogs file git openssl subversion \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
     # Cleanup apt data, we do not need them later on.
     && rm -rf /var/lib/apt/lists/* \
     # We do not have mysql-server installed but mysql-common contains config files (/etc/mysql/my.cnf) for it.

--- a/nodejs8/CHANGELOG.md
+++ b/nodejs8/CHANGELOG.md
@@ -1,5 +1,9 @@
 # IBM Functions NodeJS 8 Runtime Container
 
+# 1.41.2
+Changes:
+  - Catch latest security fixes with each build.
+
 # 1.41.1
 Changes:
   - update to a newer base image to catch fixes

--- a/nodejs8/Dockerfile
+++ b/nodejs8/Dockerfile
@@ -1,8 +1,8 @@
 FROM openwhisk/action-nodejs-v8:3e843c0
 COPY ./package.json /
 RUN apt-get update \
-    # Update some installed packages to get security fixes.
-    && apt-get install -y --no-install-recommends curl \
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    && apt-get upgrade -y --no-install-recommends \
     # Cleanup apt data, we do not need them later on.
     && rm -rf /var/lib/apt/lists/* \
     # Start adding/updating npm packages.


### PR DESCRIPTION
We changed the Dockerfiles to always get the latest security fixes (`apt-get upgrade`) for the installed packages with every build. Reason for that is, that the base images are updated with various frequencies. And in order to always have the most recent security fixes we also add them here.
In case the base image is already up to date, the `apt-get upgrade` becomes a no operation action. Otherwise it will add the security updates available since the base image was last build. Once the base image is updated, the fixes are available already and the `apt-get upgrade` here is a no operation action again. 