### PR TITLE
Add migration statement, cradle not available for nodejs:10.

### DIFF
--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -6,6 +6,7 @@
   *Attention:* This package is deprecated and is not supported anymore. It will not receive updates and will be removed in the future. Move your action to the successor package `ibm-watson`.
 - The `ibm-watson` npm package available in `nodejs:10` is version 4.x. This package is the successor of package `watson-developer-cloud`. Upgrade your action code to this new package, since the former will not receive updates anymore. This version includes support for Promises. [A list of the changes made is documented](https://github.com/watson-developer-cloud/node-sdk/blob/master/UPGRADE-4.0.md).
 - The package `ibmiotf` has been renamed by the maintainers to `@wiotp/sdk`. Make sure to update your action code to the new package. See https://www.npmjs.com/package/@wiotp/sdk for all changes. The package `ibmiotf` will not receive updates anymore and will be removed from this runtime in the future.
+- The `cradle` NPM package is not available in nodejs:10.
 
 
 # 1.15.1

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -24,9 +24,12 @@ task testWithoutCredentials(type: Test) {
 task testBlueCI(type: Test) {
   exclude '**/IBMNodeJsActionDB2Tests*'
 }
+
 task testBlueDeployment(type: Test) {
   include 'runtime/integration/**'
   include 'runtime/sdk/**'
+  // BlueDeployment does not contain nodejs12, yet. Therefore we exclude all NodeJs12 tests.
+  exclude '**/*NodeJs12*'
 }
 
 dependencies {


### PR DESCRIPTION
  - Update CHANGELOG.md for nodejs:10 to mention that the cradle package is not available in nodejs:10.
  - The BlueDeployment does not contain nodejs12. We therefore exclude the nodejs12 tests from there for now.
      Once BlueDeployment also contains nodejs12 this will be removed.