### PR TITLE
Update NodeJS to consume Fixes

### DIFF
--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -9,6 +9,10 @@
 - The `cradle` NPM package is not available in nodejs:10.
 
 
+# 1.15.2
+NodeJS version:
+  - [10.21.0](https://nodejs.org/en/blog/release/v10.21.0)
+
 # 1.15.1
 Changes:
   - Catch latest security fixes with each build.

--- a/nodejs10/Dockerfile
+++ b/nodejs10/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-nodejs-v10:7aca443
+FROM openwhisk/action-nodejs-v10:240ada7
 
 COPY ./package.json /
 

--- a/nodejs12/CHANGELOG.md
+++ b/nodejs12/CHANGELOG.md
@@ -8,7 +8,7 @@
 Initial release.
 
 NodeJS version:
-  - [12.15.0](https://nodejs.org/en/blog/release/v12.15.0/)
+  - [12.18.0](https://nodejs.org/en/blog/release/v12.18.0/)
 
 NPM version:
   - [6.13.4](https://github.com/npm/cli/releases/tag/v6.13.4)

--- a/nodejs12/Dockerfile
+++ b/nodejs12/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-nodejs-v12:7aca443
+FROM openwhisk/action-nodejs-v12:240ada7
 
 COPY ./package.json /
 


### PR DESCRIPTION
upgrade NodeJS to 12.18.0 and 10.21.0