### PR TITLE
Adapt tests to Watson translation service response changes.

### DIFF
--- a/tests/src/test/scala/runtime/integration/CredentialsIBMNodeJsActionWatsonTests.scala
+++ b/tests/src/test/scala/runtime/integration/CredentialsIBMNodeJsActionWatsonTests.scala
@@ -67,7 +67,7 @@ class CredentialsIBMNodeJsActionWatsonTests
       val response = activation.response
       response.result.get.fields.get("error") shouldBe empty
       response.result.get.fields.get("translations") should be(
-        Some(JsArray(JsObject("translation" -> JsString("Hola")))))
+        Some(JsArray(JsObject("translation" -> JsString("hola")))))
     }
 
   }


### PR DESCRIPTION
  - Watson translation service response changed to be lower case, now. Adjust the expected result in the test case to be lower case, too.