### PR TITLE
Update Openwhisk base images to gather updates

### DIFF
--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -8,7 +8,10 @@
 - The package `ibmiotf` has been renamed by the maintainers to `@wiotp/sdk`. Make sure to update your action code to the new package. See https://www.npmjs.com/package/@wiotp/sdk for all changes. The package `ibmiotf` will not receive updates anymore and will be removed from this runtime in the future.
 - The `cradle` NPM package is not available in nodejs:10.
 
-
+# 1.16.1
+NodeJS version:
+  - [10.22.1](https://nodejs.org/en/blog/release/v10.22.1)
+  
 # 1.16.0
 Changes:
   - update to a newer base image to catch security fixes

--- a/nodejs10/Dockerfile
+++ b/nodejs10/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-nodejs-v10:6896c0d
+FROM openwhisk/action-nodejs-v10:3c917b5
 
 COPY ./package.json /
 

--- a/nodejs10/package.json
+++ b/nodejs10/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-functions-runtime-nodejs-v10",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "IBM Functions",
   "repository": {
     "type": "git",

--- a/nodejs12/CHANGELOG.md
+++ b/nodejs12/CHANGELOG.md
@@ -5,6 +5,10 @@
   - The `ibmiotf` package is renamed to `@wiotp/sdk`. See https://www.npmjs.com/package/@wiotp/sdk for all changes.
   - The `request` package is deprecated and therefore not available in this runtime.
 
+# 1.0.1
+NodeJS version:
+  - [12.18.4](https://nodejs.org/en/blog/release/v12.18.4/)
+
 # 1.0.0
 Initial release.
 

--- a/nodejs12/Dockerfile
+++ b/nodejs12/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-nodejs-v12:6896c0d
+FROM openwhisk/action-nodejs-v12:3c917b5
 
 COPY ./package.json /
 

--- a/nodejs12/package.json
+++ b/nodejs12/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-functions-runtime-nodejs-v12",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "IBM Functions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update NodeJS by adopting the latest Openwhisk runtime images:
 - Node.js v10.22.1
 - Node.js v12.18.4