### PR TITLE
Gather NodeJS fixes

### DIFF
--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -8,10 +8,14 @@
 - The package `ibmiotf` has been renamed by the maintainers to `@wiotp/sdk`. Make sure to update your action code to the new package. See https://www.npmjs.com/package/@wiotp/sdk for all changes. The package `ibmiotf` will not receive updates anymore and will be removed from this runtime in the future.
 - The `cradle` NPM package is not available in nodejs:10.
 
+# 1.16.2
+NodeJS version:
+  - [10.23.0](https://nodejs.org/en/blog/release/v10.23.0)
+
 # 1.16.1
 NodeJS version:
   - [10.22.1](https://nodejs.org/en/blog/release/v10.22.1)
-  
+
 # 1.16.0
 Changes:
   - update to a newer base image to catch security fixes

--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -9,6 +9,9 @@
 - The `cradle` NPM package is not available in nodejs:10.
 
 # 1.16.2
+Changes:
+ - update openwhisk from `3.21.2` to `3.21.3`
+
 NodeJS version:
   - [10.23.0](https://nodejs.org/en/blog/release/v10.23.0)
 

--- a/nodejs10/Dockerfile
+++ b/nodejs10/Dockerfile
@@ -1,4 +1,4 @@
-FROM openwhisk/action-nodejs-v10:3c917b5
+FROM openwhisk/action-nodejs-v10:5a34ace
 
 COPY ./package.json /
 

--- a/nodejs10/package.json
+++ b/nodejs10/package.json
@@ -50,7 +50,7 @@
     "nano": "8.0.0",
     "nodemailer": "5.1.1",
     "oauth2-server": "3.0.2",
-    "openwhisk": "3.21.2",
+    "openwhisk": "3.21.3",
     "path-to-regexp": "3.0.0",
     "pg": "7.11.0",
     "process": "0.11.10",

--- a/nodejs12/CHANGELOG.md
+++ b/nodejs12/CHANGELOG.md
@@ -5,6 +5,10 @@
   - The `ibmiotf` package is renamed to `@wiotp/sdk`. See https://www.npmjs.com/package/@wiotp/sdk for all changes.
   - The `request` package is deprecated and therefore not available in this runtime.
 
+# 1.0.2
+NodeJS version:
+  - [12.19.1](https://nodejs.org/en/blog/release/v12.19/)
+
 # 1.0.1
 NodeJS version:
   - [12.18.4](https://nodejs.org/en/blog/release/v12.18.4/)

--- a/nodejs12/CHANGELOG.md
+++ b/nodejs12/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 # 1.0.2
 NodeJS version:
-  - [12.19.1](https://nodejs.org/en/blog/release/v12.19/)
+  - [12.19.1](https://nodejs.org/en/blog/release/v12.19.1/)
 
 # 1.0.1
 NodeJS version:

--- a/nodejs12/CHANGELOG.md
+++ b/nodejs12/CHANGELOG.md
@@ -6,6 +6,9 @@
   - The `request` package is deprecated and therefore not available in this runtime.
 
 # 1.0.2
+Changes:
+ - update openwhisk from `3.21.2` to `3.21.3`
+
 NodeJS version:
   - [12.19.1](https://nodejs.org/en/blog/release/v12.19.1/)
 

--- a/nodejs12/Dockerfile
+++ b/nodejs12/Dockerfile
@@ -1,4 +1,5 @@
-FROM openwhisk/action-nodejs-v12:3c917b5
+
+FROM openwhisk/action-nodejs-v12:5a34ace
 
 COPY ./package.json /
 

--- a/nodejs12/package.json
+++ b/nodejs12/package.json
@@ -56,7 +56,7 @@
     "needle": "2.5.0",
     "nodemailer": "6.4.10",
     "oauth2-server": "3.0.2",
-    "openwhisk": "3.21.2",
+    "openwhisk": "3.21.3",
     "path-to-regexp": "6.1.0",
     "pg": "8.2.1",
     "process": "0.11.10",


### PR DESCRIPTION
Update NodeJS to v10.23.0 and v12.19.1 to gather fixes