### PR TITLE
Running privileged containers is not possible in all environments.

### DIFF
--- a/tests/src/test/scala/runtime/actionContainers/IBMNodeJsActionDB2Tests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/IBMNodeJsActionDB2Tests.scala
@@ -104,6 +104,10 @@ class IBMNodeJsActionDB2Tests extends TestHelpers with WskTestHelpers with Befor
       "docker",
       "run",
       "-d",
+      "--cap-add",
+      "IPC_LOCK",
+      "--cap-add",
+      "IPC_OWNER",
       "-p",
       "50000:50000",
       "-e",
@@ -112,7 +116,6 @@ class IBMNodeJsActionDB2Tests extends TestHelpers with WskTestHelpers with Befor
       "DB2INST1_PASSWORD=db2inst1-pwd",
       "-e",
       "LICENSE=accept",
-      "--privileged=true",
       "--name",
       db2containerName,
       "ibmcom/db2")


### PR DESCRIPTION
  With actual docker installations it is now possible to get the required permissions for the ibmcom/db2
  containers also via '--cap-add' statements (db2 requires larger shared memory than the default allows).
  Adding '--cap-add IPC_LOCK'  and '--cap-add IPC_OWNER' allows to remove the '--privileged=true' and still run ibmcom/db2 successfully.