### PR TITLE
Remove nodejs:8 tests from testBlueDeployment.

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -28,8 +28,16 @@ task testBlueCI(type: Test) {
 task testBlueDeployment(type: Test) {
   include 'runtime/integration/**'
   include 'runtime/sdk/**'
+
   // To exlude tests from the BlueDeployment, place them here. See sample to exclude all NodeJs12 tests, below.
   // exclude '**/*NodeJs12*'
+
+  // Exclude the nodejs:8 specific tests as this runtime is deprecated.
+  exclude '**/*IBMNodeJsActionCloudant*'
+  exclude '**/*IBMNodeJsActionWatson*'
+  exclude '**/*IBMNodeJsCOS*'
+  exclude '**/*IBMNodeJsDb2Cloud*'
+  exclude '**/*NodeJsSDK*'
 }
 
 dependencies {


### PR DESCRIPTION
- The nodejs:8 runtime is deprecated as NodeJs 8 went out of support. We therefore do not executed the related tests in testBlueDeployment until the nodejs:8 runtime is fully removed here.