### PR TITLE
Update nodejs:12 to node 12.22.5.

### DIFF
--- a/nodejs12/CHANGELOG.md
+++ b/nodejs12/CHANGELOG.md
@@ -5,6 +5,13 @@
   - The `ibmiotf` package is renamed to `@wiotp/sdk`. See https://www.npmjs.com/package/@wiotp/sdk for all changes.
   - The `request` package is deprecated and therefore not available in this runtime.
 
+# 1.1.3
+Changes:
+  - update to nodejs 12.22.5
+
+NodeJS version:
+  - [12.22.5](https://nodejs.org/en/blog/release/v12.22.5/)
+
 # 1.1.2
 Changes:
   - openwhisk from `3.21.3` to `3.21.4`

--- a/nodejs12/Dockerfile
+++ b/nodejs12/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openwhisk/action-nodejs-v12:99cb7ae
+FROM openwhisk/action-nodejs-v12:341ea16
 
 COPY ./package.json /
 


### PR DESCRIPTION
- Update parent image to new version to include node 12.22.5 to get latest node security fixes.