### PR TITLE
Build nodejs:16 runtime image with --no-cache.

### DIFF
--- a/nodejs16/build.gradle
+++ b/nodejs16/build.gradle
@@ -4,6 +4,10 @@ apply from: '../gradle/docker.gradle'
 distDocker.dependsOn 'copyIAMClient'
 distDocker.finalizedBy('cleanup')
 
+// To always get the latest vulnerability updates into the image, use --no-cache for building the image.
+// This is not needed for travis builds (the VM is always new), but for local development.
+dockerBuildArg = ['build','--no-cache']
+
 task copyIAMClient(type: Copy) {
     from '../iam-client'
     into 'iam-client'


### PR DESCRIPTION
- Run docker build with --no-cache for nodejs:16 to always get latest security updates into the image. For travis builds this is not required (travis vm is always empty). But local builds usually use the cache to speed up the build. They would not get the updates unless the Dockerfile is changed somewhere before the update/upgrade or the docker cache is cleared.