### PR TITLE
Adds Joi as a pre-installed module (fix #261)

### DIFF
--- a/nodejs16/package.json
+++ b/nodejs16/package.json
@@ -41,6 +41,7 @@
     "ibm-watson": "7.0.0",
     "iconv-lite": "0.6.3",
     "jest": "27.5.1",
+    "joi": "^17.9.1",
     "jsdom": "19.0.0",
     "jsforce": "1.11.0",
     "jsonwebtoken": "8.5.1",


### PR DESCRIPTION
This PR adds the Joi Module to the pre-installed module list, this module is very helpful since it allows us to validate the parameters sent to the API before doing anything with it.

Fix #261 