### PR TITLE
Remove nodejs:10, nodejs:12 and nodejs:14 from supported runtimes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 [![Build Status](https://travis-ci.org/ibm-functions/runtime-nodejs.svg?branch=master)](https://travis-ci.com/ibm-functions/runtime-nodejs)
 
-- The runtime provides [nodejs v10](nodejs10/) with a set of [npm packages](nodejs10/package.json) see [nodejs10/CHANGELOG.md](nodejs10/CHANGELOG.md)
-- The runtime provides [nodejs v12](nodejs12/) with a set of [npm packages](nodejs12/package.json) see [nodejs12/CHANGELOG.md](nodejs12/CHANGELOG.md)
-- The runtime provides [nodejs v14](nodejs14/) with a set of [npm packages](nodejs14/package.json) see [nodejs14/CHANGELOG.md](nodejs14/CHANGELOG.md)
 - The runtime provides [nodejs v16](nodejs16/) with a set of [npm packages](nodejs16/package.json) see [nodejs16/CHANGELOG.md](nodejs16/CHANGELOG.md)
 
 
@@ -18,40 +15,34 @@ The runtime provides the following npm packages for [IBM Cloud](https://bluemix.
 ### How to use as a docker Action
 To use as a docker action
 ```
-ibmcloud wsk action update myAction myAction.js --docker ibmfunctions/action-nodejs-ibm-v10
+ibmcloud wsk action update myAction myAction.js --docker ibmfunctions/action-nodejs-ibm-v16
 ```
 This works on any deployment of Apache OpenWhisk or IBM Cloud Functions
 
 ### Future: IBM Cloud Functions (based on Apache OpenWhisk)
 To use as a nodejs kind action
 ```
-ibmcloud wsk action update myAction myAction --kind nodejs:10
+ibmcloud wsk action update myAction myAction --kind nodejs:16
 ```
 Tip: Not available yet in the IBM Cloud
 
 ### Working with the local git repo
 Prerequisite: *Export* OPENWHISK_HOME to point to your incubator/openwhisk cloned directory.
 
-To build the `nodejs:10` runtime:
+To build the `nodejs:16` runtime:
 ```
-./gradlew nodejs10:distDocker
+./gradlew nodejs16:distDocker
 ```
-This will produce the image `whisk/action-nodejs-ibm-v10`
-
-To build the `nodejs:12` runtime:
-```
-./gradlew nodejs12:distDocker
-```
-This will produce the image `whisk/action-nodejs-ibm-v12`
+This will produce the image `whisk/action-nodejs-ibm-v16`
 
 
 Build and Push image
 ```
 docker login
-./gradlew nodejs10:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
+./gradlew nodejs16:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
 ```
 
-Deploy OpenWhisk using ansible environment that adds the new king `nodejs:10`
+Deploy OpenWhisk using ansible environment that adds the new king `nodejs:16`
 Assuming you have OpenWhisk already deploy localy and `OPENWHISK_HOME` pointing to root directory of OpenWhisk core repository.
 
 Set `ROOTDIR` to the root directory of this repository.
@@ -69,12 +60,12 @@ $ANSIBLE_CMD openwhisk.yml
 
 To use as docker action push to your own dockerhub account
 ```
-docker tag whisk/action-nodejs-ibm-v10 $user_prefix/action-nodejs-ibm-v10
-docker push $user_prefix/action-nodejs-ibm-v10
+docker tag whisk/action-nodejs-ibm-v16 $user_prefix/action-nodejs-ibm-v16
+docker push $user_prefix/action-nodejs-ibm-v16
 ```
 Then create the action using your the image from dockerhub
 ```
-wsk action update myAction myAction.js --docker $user_prefix/action-nodejs-ibm-v10
+wsk action update myAction myAction.js --docker $user_prefix/action-nodejs-ibm-v16
 ```
 The `$user_prefix` is usually your dockerhub user id.
 
@@ -166,78 +157,6 @@ nvm ls-remote | grep v16.
   ```
   - Update [nodejs16/package.json](nodejs16/package.json)
   - Update [nodejs16/CHANGELOG.md](nodejs16/CHANGELOG.md)
-
-### Updating Node.js 14 runtime
-- Get the version of the latest tag ibm image
-```
-VERSION=$(git tag | grep 14@ | tail -2 | head -1 | awk -F"@" '{print $2 }')
-```
-- Check the version of nodejs on the latest ibm image released
-```
-docker run --rm -it ibmfunctions/action-nodejs-v14:$VERSION sh -c "node -v"
-```
-- Check if there is a new version of the [Node.js LTS 14](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md).
-```
-nvm ls-remote | grep v14.
-```
-  - If there is a new version update the [OpenWhisk Node.js 14 Dockerfile](https://github.com/apache/openwhisk-runtime-nodejs/blob/master/core/nodejs14Action/Dockerfile#L18) and submit PR.
-  - After PR is merged wait for Travis CI to build and push a new tag image for [openwhisk/action-nodejs-v14](https://hub.docker.com/r/openwhisk/action-nodejs-v14/tags)
-  - Update the ibm image [nodejs14/Dockerfile](nodejs14/Dockerfile) FROM usign the new upstream tag
-- Check if there are new npm packages available
-  - Use the latest released image to check the outdated npm packages
-  ```
-  docker run --rm -it ibmfunctions/action-nodejs-v14:$VERSION sh -c "cd / && npm outdated"
-  ```
-  - Update [nodejs14/package.json](nodejs14/package.json)
-  - Update [nodejs14/CHANGELOG.md](nodejs14/CHANGELOG.md)
-
-### Updating Node.js 12 runtime
-- Get the version of the latest tag ibm image
-```
-VERSION=$(git tag | grep 12@ | tail -2 | head -1 | awk -F"@" '{print $2 }')
-```
-- Check the version of nodejs on the latest ibm image released
-```
-docker run --rm -it ibmfunctions/action-nodejs-v12:$VERSION sh -c "node -v"
-```
-- Check if there is a new version of the [Node.js LTS 12](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md).
-```
-nvm ls-remote | grep v12.
-```
-  - If there is a new version update the [OpenWhisk Node.js 12 Dockerfile](https://github.com/apache/openwhisk-runtime-nodejs/blob/master/core/nodejs12Action/Dockerfile#L18) and submit PR.
-  - After PR is merged wait for Travis CI to build and push a new tag image for [openwhisk/action-nodejs-v12](https://hub.docker.com/r/openwhisk/action-nodejs-v12/tags)
-  - Update the ibm image [nodejs12/Dockerfile](nodejs12/Dockerfile) FROM usign the new upstream tag
-- Check if there are new npm packages available
-  - Use the latest released image to check the outdated npm packages
-  ```
-  docker run --rm -it ibmfunctions/action-nodejs-v12:$VERSION sh -c "cd / && npm outdated"
-  ```
-  - Update [nodejs12/package.json](nodejs12/package.json)
-  - Update [nodejs12/CHANGELOG.md](nodejs12/CHANGELOG.md)
-
-### Updating Node.js 10 runtime
-- Get the version of the latest tag ibm image
-```
-VERSION=$(git tag | grep 10@ | tail -2 | head -1 | awk -F"@" '{print $2 }')
-```
-- Check the version of nodejs on the latest ibm image released
-```
-docker run --rm -it ibmfunctions/action-nodejs-v10:$VERSION sh -c "node -v"
-```
-- Check if there is a new version of the [Node.js LTS 10](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md).
-```
-nvm ls-remote | grep v10.
-```
-  - If there is a new version update the [OpenWhisk Node.js 10 Dockerfile](https://github.com/apache/openwhisk-runtime-nodejs/blob/master/core/nodejs10Action/Dockerfile#L18) and submit PR.
-  - After PR is merged wait for Travis CI to build and push a new tag image for [openwhisk/action-nodejs-v10](https://hub.docker.com/r/openwhisk/action-nodejs-v10/tags)
-  - Update the ibm image [nodejs10/Dockerfile](nodejs10/Dockerfile) FROM usign the new upstream tag
-- Check if there are new npm packages available
-  - Use the latest released image to check the outdated npm packages
-  ```
-  docker run --rm -it ibmfunctions/action-nodejs-v10:$VERSION sh -c "cd / && npm outdated"
-  ```
-  - Update [nodejs10/package.json](nodejs10/package.json)
-  - Update [nodejs10/CHANGELOG.md](nodejs10/CHANGELOG.md)
 
 ### Pushing new versions for runtimes
 - After the PR is merged and the master pass Travis CI, checkout master.

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -31,21 +31,6 @@ skip_pull_runtimes: true
 runtimes_manifest:
   runtimes:
     nodejs:
-    - kind: "nodejs:10"
-      default: false
-      image:
-        name: "action-nodejs-v10"
-      deprecated: false
-    - kind: "nodejs:12"
-      default: false
-      image:
-        name: "action-nodejs-v12"
-      deprecated: false
-    - kind: "nodejs:14"
-      default: false
-      image:
-        name: "action-nodejs-v14"
-      deprecated: false
     - kind: "nodejs:16"
       default: true
       image:

--- a/nodejs10/CHANGELOG.md
+++ b/nodejs10/CHANGELOG.md
@@ -1,5 +1,8 @@
 # IBM Functions NodeJS 10 Runtime Container
 
+# Attention
+This runtime is deprecated and will not be supported anymore. The code is still here for reference only and might be deleted at any time!
+
 ## Migrating from `nodejs:8` to `nodejs:10`
 - The `cloudant` npm package is not available in `nodejs:10`, the package is deprecated, you need to use the official npm package [@cloudant/cloudant](https://www.npmjs.com/package/@cloudant/cloudant) v3.x when importing the nodejs module (i.e `require('@cloudant/cloudant')`) also [v3.x only returns Promises](https://github.com/cloudant/nodejs-cloudant/blob/master/api-migration.md#2x--3x).
 - The `watson-developer-cloud` npm package available in `nodejs:10` is version 4.x. This version includes support for Promises. [A list of the changes made is documented](https://github.com/watson-developer-cloud/node-sdk/blob/master/UPGRADE-4.0.md).

--- a/nodejs12/CHANGELOG.md
+++ b/nodejs12/CHANGELOG.md
@@ -1,5 +1,8 @@
 # IBM Functions NodeJS 12 Runtime Container
 
+# Attention
+This runtime is deprecated and will not be supported anymore. The code is still here for reference only and might be deleted at any time!
+
 ## Migrating from `nodejs:10` to `nodejs:12`
   - The ibm-watson sdk version moved to 6.x. It includes a number of breaking changes. See https://github.com/watson-developer-cloud/node-sdk/blob/HEAD/MIGRATION-V6.md for details.
   - The `ibmiotf` package is renamed to `@wiotp/sdk`. See https://www.npmjs.com/package/@wiotp/sdk for all changes.

--- a/nodejs14/CHANGELOG.md
+++ b/nodejs14/CHANGELOG.md
@@ -1,4 +1,7 @@
-# IBM Functions NodeJS 12 Runtime Container
+# IBM Functions NodeJS 14 Runtime Container
+
+# Attention
+This runtime is deprecated and will not be supported anymore. The code is still here for reference only and might be deleted at any time!
 
 ## Migrating from `nodejs:12` to `nodejs:14`
   - The `@cloudant/cloudant` package is deprecated and therefore not available in this runtime. Please see the [Migration Guide](https://github.com/cloudant/nodejs-cloudant/blob/HEAD/MIGRATION.md) for advice about migrating to the replacement library [@ibm-cloud/cloudant](https://github.com/IBM/cloudant-node-sdk).  

--- a/nodejs8/CHANGELOG.md
+++ b/nodejs8/CHANGELOG.md
@@ -1,5 +1,8 @@
 # IBM Functions NodeJS 8 Runtime Container
 
+# Attention
+This runtime is deprecated and will not be supported anymore. The code is still here for reference only and might be deleted at any time!
+
 # 1.42.0
 Changes:
   - update lodash from `4.17.13` to `4.17.19` (security fixes)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,5 @@
 include 'tests'
 
-include 'nodejs10'
-include 'nodejs12'
-include 'nodejs14'
 include 'nodejs16'
 
 rootProject.name = 'runtime-nodejs-ibm'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -15,6 +15,22 @@ tasks.withType(Test) {
         exceptionFormat = 'full'
     }
     outputs.upToDateWhen { false } // force tests to run every time
+
+    // Exclude the nodejs:10 specific tests as this runtime is not supported anymore.
+    exclude '**/*NodeJs10*'
+
+    // Exclude the nodejs:12 specific tests as this runtime is not supported anymore.
+    exclude '**/*NodeJs12*'
+
+    // Exclude the nodejs:14 specific tests as this runtime is not supported anymore.
+    exclude '**/*IBMNodeJsActionContainerTests*'
+    exclude '**/*IBMNodeJsActionDB2Tests*'
+    exclude '**/*IBMNodeJsActionCloudant*'
+    exclude '**/*IBMNodeJsActionWatson*'
+    exclude '**/*IBMNodeJsCOS*'
+    exclude '**/*IBMNodeJsDb2Cloud*'
+    exclude '**/*NodeJsSDK*'
+
 }
 
 task testWithoutCredentials(type: Test) {


### PR DESCRIPTION
Remove older node versions (nodejs:10, nodejs:12, nodejs:14) from the supported runtimes. This means do not build them, test them and also do not publish updated images of them.