### PR TITLE
Update Base image 28ac4c0

### DIFF
--- a/nodejs16/CHANGELOG.md
+++ b/nodejs16/CHANGELOG.md
@@ -7,6 +7,20 @@
   - Mongodb drivers have been upgraded to version 4 please check the [Upgrade Guide](https://github.com/mongodb/node-mongodb-native/blob/HEAD/docs/CHANGES_4.0.0.md)
   - The `redis` package has been updated to version 4 please check the [Migration Guide](https://github.com/redis/node-redis/blob/HEAD/docs/v3-to-v4.md)
 
+# 1.0.6
+  Changes:
+  - Update base image to latest Openwhisk Tag 28ac4c0
+  
+  NodeJS version:
+  - v16.20.0
+
+  NPM version:
+  - v8.19.4
+
+  NodeJS packages:
+  - The file [package.json](package.json) lists the packages we guarantee to be included in this runtime.
+    Ensure that you only use packages mentioned there. Other nodejs packages might be part of this runtime, but only due to indirect dependencies of the above listed packages. These indirectly included packages are candidates to be removed at any time in case they are not required by the referring package anymore.
+
 # 1.0.5
   Changes:
   - Update base image to latest Openwhisk Tag 577ccbb

--- a/nodejs16/Dockerfile
+++ b/nodejs16/Dockerfile
@@ -41,4 +41,6 @@ RUN apt-get update  \
     # Show full list of installed modules.
     && echo "npm list:" && echo "$(cd / && npm list)"
 
+ENV OW_ENABLE_INIT_INSTALL=false
+
 COPY iam-client/iam-openwhisk-main.js /node_modules/openwhisk/lib/

--- a/nodejs16/Dockerfile
+++ b/nodejs16/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openwhisk/action-nodejs-v16:577ccbb
+FROM openwhisk/action-nodejs-v16:28ac4c0
 
 COPY ./package.json /
 


### PR DESCRIPTION
- Update Openwhisk Base image to 28ac4c0
- adds Ability to disable or enable the npm install during init